### PR TITLE
[tooltip] Missing import

### DIFF
--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -1,5 +1,6 @@
 import { customElement, html, TemplateResult } from "lit-element";
 import { IPopoverProperties, Popover } from "../popover/popover";
+import "../popover-card/popover-card";
 import { cssResult } from "../util/css";
 
 import styles from "./tooltip.scss";


### PR DESCRIPTION
add missing import to tooltip that use popover-card