### PR TITLE
Arrow should ignore pointer-events

### DIFF
--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -8,6 +8,7 @@
 	top: 50%;
 	right: 0;
 	transform: translate(-100%, -50%);
+	pointer-events: none;
 }
 
 ::slotted(option) {


### PR DESCRIPTION
When you click onto the arrow, `wl-select` does not show his options.