### PR TITLE
Fix label for datetime-local

### DIFF
--- a/src/lib/behavior/input/input-behavior.scss
+++ b/src/lib/behavior/input/input-behavior.scss
@@ -89,7 +89,7 @@
 	--_input-state-color: #{$input-state-color-active};
 }
 
-:host([dirty]), :host(:focus-within), :host([type="color"]), :host([type="date"]), :host([type="file"]), :host([type="range"]) {
+:host([dirty]), :host(:focus-within), :host([type="color"]), :host([type="date"]), :host([type="datetime-local"]), :host([type="file"]), :host([type="range"]) {
 	#label {
 		font-size: $input-label-font-size;
 		top: $input-padding-top-bottom;


### PR DESCRIPTION
This should fix the label floating when you use the datetime-local type on input